### PR TITLE
Add support for Filetype association #3

### DIFF
--- a/lua/victor-iyi/init.lua
+++ b/lua/victor-iyi/init.lua
@@ -23,6 +23,7 @@ require('victor-iyi.core.colorscheme')
 -- Plugins
 require('victor-iyi.plugins.comment')
 require('victor-iyi.plugins.devicons')
+require('victor-iyi.plugins.filetype')
 require('victor-iyi.plugins.lualine')
 require('victor-iyi.plugins.nvim-cmp')
 require('victor-iyi.plugins.nvim-tree')

--- a/lua/victor-iyi/packer.lua
+++ b/lua/victor-iyi/packer.lua
@@ -145,6 +145,9 @@ return packer.startup(function(use)
     requires = { {'nvim-lua/plenary.nvim'} },
   }
 
+  -- File assocoiation
+  use 'nathom/filetype.nvim'
+
   -- Changes working directory to project root.
   use 'airblade/vim-rooter'
 

--- a/lua/victor-iyi/plugins/filetype.lua
+++ b/lua/victor-iyi/plugins/filetype.lua
@@ -1,0 +1,65 @@
+-- Copyright 2022 Victor I. Afolabi
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- Some servers have issues with backup files, see #649.
+
+-- URL: https://github.com/victor-iyi/nvim/issues/3
+local status, filetype = pcall(require, 'filetype')
+
+if not status then
+  return
+end
+
+filetype.setup({
+  overrides = {
+    -- Set the filetype of {key} to {value]
+    extensions = {
+      -- pn = 'potion',
+    },
+    -- Set filetype of {key} to {value}
+    literal = {
+      -- MyBackupFile = 'lua',
+    },
+    -- Set the filetype of any full filename matching the regex to {value}
+    complex = {
+      ['[\\.]?aliases'] = 'sh',
+      ['[\\.]?functions'] = 'sh',
+    },
+
+    -- The same as the ones above except the keys map to functions.
+    function_extensions = {
+      -- ['pdf'] = function()
+      --   vim.bo.filetype = 'pdf'
+      --   -- Open in PDF viewer (Skim.app) automattically.
+      --   vim.fn.jobstart(
+      --     'open -a skim ' .. '"' .. vim.fn.expand('%') .. '"'
+      --   )
+      -- end,
+    },
+    function_literal = {
+      -- Brewfile = function()
+      --   vim.cmd('syntax off')
+      -- end,
+    },
+    function_complex = {
+      ['*.math_notes/%w+'] = function()
+        vim.cmd('iabbrev $ $$')
+      end,
+    },
+
+    -- Set the filetype of files with a {key} shebang to sh
+    shebang = {
+      -- dash = 'sh',
+    }
+  },
+})


### PR DESCRIPTION
Support for filetype association has been added with [filetype] package.

To add custom file association, edit the `lua/victor-iyi/plugins/filetype.lua`.

[filetype]: https://github.com/nathom/filetype.nvim